### PR TITLE
Add map visualization for swell and wind directions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,12 @@
       "name": "swell-forecast",
       "version": "0.1.0",
       "dependencies": {
+        "leaflet": "^1.9.4",
+        "leaflet-defaulticon-compatibility": "^0.1.2",
         "next": "15.5.4",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "react-leaflet": "^5.0.0",
         "recharts": "^3.2.1",
         "tz-lookup": "^6.1.25"
       },
@@ -901,6 +904,16 @@
       "dev": true,
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -4154,6 +4167,16 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
+    },
+    "node_modules/leaflet-defaulticon-compatibility": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/leaflet-defaulticon-compatibility/-/leaflet-defaulticon-compatibility-0.1.2.tgz",
+      "integrity": "sha512-IrKagWxkTwzxUkFIumy/Zmo3ksjuAu3zEadtOuJcKzuXaD76Gwvg2Z1mLyx7y52ykOzM8rAH5ChBs4DnfdGa6Q=="
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -4973,6 +4996,19 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
     },
     "node_modules/react-redux": {
       "version": "9.2.0",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,12 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "leaflet": "^1.9.4",
+    "leaflet-defaulticon-compatibility": "^0.1.2",
     "next": "15.5.4",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "react-leaflet": "^5.0.0",
     "recharts": "^3.2.1",
     "tz-lookup": "^6.1.25"
   },

--- a/src/app/components/RadarCard.tsx
+++ b/src/app/components/RadarCard.tsx
@@ -21,6 +21,11 @@ import {
   Cell,
 } from "recharts";
 
+import { MapContainer, TileLayer, Marker, Popup } from "react-leaflet";
+import "leaflet/dist/leaflet.css";
+
+import SpotMap from "./SpotMap";
+
 // -----------------------------------------------------------------------------
 // RadarCard – Fetches /api/forecast?spot_id=trigg and renders:
 // 1) A radar (snowflake) chart of component scores (0..1)
@@ -79,7 +84,12 @@ type DirectionArrowProps = {
   offsetX?: number;
 };
 
-function DirectionArrow({ degrees, color, label, offsetX = 0 }: DirectionArrowProps) {
+function DirectionArrow({
+  degrees,
+  color,
+  label,
+  offsetX = 0,
+}: DirectionArrowProps) {
   if (degrees == null || Number.isNaN(degrees)) return null;
   return (
     <div
@@ -109,84 +119,6 @@ function DirectionArrow({ degrees, color, label, offsetX = 0 }: DirectionArrowPr
         </div>
         <div className="mt-2 rounded-full bg-black/70 px-2 py-0.5 text-xs text-white">
           {label}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-type SpotMapProps = {
-  spot: SpotSummary | null;
-  swellDeg: number | null | undefined;
-  windDeg: number | null | undefined;
-  windSpeed: number | null | undefined;
-};
-
-function SpotMap({ spot, swellDeg, windDeg, windSpeed }: SpotMapProps) {
-  const url = useMemo(() => {
-    if (!spot) return null;
-    const zoom = 12;
-    const size = "600x400";
-    const marker = `${spot.lat.toFixed(5)},${spot.lon.toFixed(5)},lightblue1`;
-    return `https://staticmap.openstreetmap.de/staticmap.php?center=${spot.lat.toFixed(
-      5,
-    )},${spot.lon.toFixed(5)}&zoom=${zoom}&size=${size}&maptype=mapnik&markers=${marker}`;
-  }, [spot]);
-
-  if (!spot || !url) return null;
-
-  const swellLabel =
-    swellDeg == null || Number.isNaN(swellDeg)
-      ? null
-      : `Swell ${Math.round(swellDeg)}°`;
-  const windLabel =
-    windDeg == null || Number.isNaN(windDeg)
-      ? null
-      : `Wind ${Math.round(windDeg)}°${
-          windSpeed != null && !Number.isNaN(windSpeed)
-            ? ` · ${(windSpeed * 1.94384).toFixed(0)} kt`
-            : ""
-        }`;
-
-  return (
-    <div className="rounded-xl border border-gray-200 bg-gray-50">
-      <div className="relative h-64 overflow-hidden rounded-t-xl">
-        <img
-          src={url}
-          alt={`Map showing ${spot.name}`}
-          className="h-full w-full object-cover"
-          loading="lazy"
-        />
-        <div className="absolute inset-0 bg-gradient-to-b from-black/0 via-black/0 to-black/20" />
-        <DirectionArrow
-          degrees={swellDeg}
-          color="#0ea5e9"
-          label={swellLabel ?? "Swell direction unavailable"}
-          offsetX={-70}
-        />
-        <DirectionArrow
-          degrees={windDeg}
-          color="#f97316"
-          label={windLabel ?? "Wind direction unavailable"}
-          offsetX={70}
-        />
-        <div className="absolute left-3 top-3 rounded-lg bg-black/60 px-3 py-1 text-xs font-medium text-white shadow">
-          {spot.name}
-        </div>
-      </div>
-      <div className="flex items-center justify-between px-3 py-2 text-xs text-gray-600">
-        <div>
-          Lat {spot.lat.toFixed(3)} • Lon {spot.lon.toFixed(3)}
-        </div>
-        <div className="flex items-center gap-2">
-          <span className="flex items-center gap-1 text-sky-700">
-            <span className="inline-block h-2 w-2 rounded-full bg-sky-500" />
-            Swell
-          </span>
-          <span className="flex items-center gap-1 text-orange-700">
-            <span className="inline-block h-2 w-2 rounded-full bg-orange-400" />
-            Wind
-          </span>
         </div>
       </div>
     </div>

--- a/src/app/components/SpotMap.tsx
+++ b/src/app/components/SpotMap.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { MapContainer, TileLayer, Marker, Popup, useMap } from "react-leaflet";
+import L from "leaflet";
+import { useEffect, useMemo, useState } from "react";
+import "leaflet/dist/leaflet.css";
+import "leaflet-defaulticon-compatibility";
+import "leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.css";
+
+type Spot = { id: string; name: string; lat: number; lon: number };
+
+function Recenter({ center }: { center: [number, number] }) {
+  const map = useMap();
+  useEffect(() => {
+    map.setView(center);
+  }, [center, map]);
+  return null;
+}
+
+/** Place an inward-pointing arrow on the map edge for a given 'coming-from' bearing. */
+function EdgeArrow({
+  centerLatLng,
+  bearingFromDeg, // meteorological "from" direction
+  color = "dodgerblue",
+  paddingPx = 20, // how far inside the edge
+  lengthPx = 60, // arrow shaft length
+}: {
+  centerLatLng: [number, number];
+  bearingFromDeg: number;
+  color?: string;
+  paddingPx?: number;
+  lengthPx?: number;
+}) {
+  const map = useMap();
+  const [pos, setPos] = useState<L.LatLng | null>(null);
+
+  // Make an inward pointing arrow. We rotate by +180 so it points toward the center.
+  const icon = useMemo(
+    () =>
+      L.divIcon({
+        html: `
+      <div style="
+        transform: rotate(${bearingFromDeg + 180}deg);
+        width: 10px;
+        height: ${lengthPx}px;
+        background: ${color};
+        position: relative;
+      ">
+        <div style="
+          position: absolute;
+          bottom: -8px;
+          left: -6px;
+          width: 0; height: 0;
+          border-left: 12px solid transparent;
+          border-right: 12px solid transparent;
+          border-top: 12px solid ${color};
+        "></div>
+      </div>
+    `,
+        className: "",
+        iconSize: [12, lengthPx],
+        iconAnchor: [6, lengthPx / 2], // keep the shaft centered on the edge point
+      }),
+    [bearingFromDeg, color, lengthPx]
+  );
+
+  useEffect(() => {
+    function recompute() {
+      const size = map.getSize(); // pixel size of map viewport
+      const centerPx = map.latLngToContainerPoint(centerLatLng);
+
+      // Unit vector for the *from* direction (bearing clockwise from north)
+      const theta = (bearingFromDeg * Math.PI) / 180;
+      const vx = Math.sin(theta); // x right
+      const vy = -Math.cos(theta); // y down (screen coords)
+
+      // We want to go from center toward the edge, in the *from* direction,
+      // so the ray is p(s) = centerPx - s * v, s >= 0.
+      const w = size.x,
+        h = size.y;
+
+      const sCandidates: number[] = [];
+
+      // Left edge x = paddingPx
+      if (vx > 1e-6) sCandidates.push((centerPx.x - paddingPx) / vx);
+      // Right edge x = w - paddingPx
+      if (vx < -1e-6) sCandidates.push((w - paddingPx - centerPx.x) / -vx);
+      // Top edge y = paddingPx
+      if (vy > 1e-6) sCandidates.push((centerPx.y - paddingPx) / vy);
+      // Bottom edge y = h - paddingPx
+      if (vy < -1e-6) sCandidates.push((h - paddingPx - centerPx.y) / -vy);
+
+      // Pick the smallest positive s (first edge hit)
+      const s = Math.min(
+        ...sCandidates.filter((x) => x >= 0 && Number.isFinite(x))
+      );
+      if (!Number.isFinite(s)) return; // no solution (shouldn't happen for non-zero v)
+
+      const edgePx = L.point(centerPx.x - s * vx, centerPx.y - s * vy);
+      const edgeLL = map.containerPointToLatLng(edgePx);
+      setPos(edgeLL);
+    }
+
+    recompute();
+    map.on("move zoom resize", recompute);
+    return () => {
+      map.off("move zoom resize", recompute);
+    };
+  }, [map, centerLatLng, bearingFromDeg, paddingPx]);
+
+  if (!pos) return null;
+  return <Marker position={pos} icon={icon} />;
+}
+
+export default function SpotMap({
+  spot,
+  windDeg,
+  swellDeg,
+}: {
+  spot: Spot | null;
+  windDeg?: number; // coming-from
+  swellDeg?: number; // coming-from
+}) {
+  const center = useMemo<[number, number]>(
+    () => [spot?.lat ?? 0, spot?.lon ?? 0],
+    [spot]
+  );
+  if (!spot) return null;
+
+  return (
+    <div className="rounded-xl overflow-hidden border border-gray-200">
+      <MapContainer
+        center={center}
+        zoom={12}
+        style={{ height: 400, width: "100%" }}
+        scrollWheelZoom={false}
+      >
+        <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+        <Recenter center={center} />
+
+        {/* Base spot marker */}
+        <Marker position={center}>
+          <Popup>{spot.name}</Popup>
+        </Marker>
+
+        {/* Edge arrows: always in view, pointing inward */}
+        {typeof windDeg === "number" && (
+          <EdgeArrow
+            centerLatLng={center}
+            bearingFromDeg={windDeg + 180}
+            color="dodgerblue"
+          />
+        )}
+        {typeof swellDeg === "number" && (
+          <EdgeArrow
+            centerLatLng={center}
+            bearingFromDeg={swellDeg + 180}
+            color="mediumseagreen"
+          />
+        )}
+      </MapContainer>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a spot map component that renders a static map with overlay arrows for swell and wind directions
- place the map beside the radar chart and keep it in sync with the selected hour from the bar chart hover

## Testing
- npm run lint *(fails: existing lint rule violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e35c3b47688328a2f0116942d655f9